### PR TITLE
Initialize InstallPlanner platform

### DIFF
--- a/installerplanner/.env.example
+++ b/installerplanner/.env.example
@@ -1,0 +1,2 @@
+WEB_ORIGIN=http://localhost:3000
+NEXT_PUBLIC_API_BASE=http://localhost:8000

--- a/installerplanner/.gitignore
+++ b/installerplanner/.gitignore
@@ -1,0 +1,12 @@
+.env
+__pycache__/
+*.pyc
+node_modules/
+.next/
+.DS_Store
+.env.local
+.env.production
+.env.development
+.pytest_cache/
+venv/
+.venv/

--- a/installerplanner/README.md
+++ b/installerplanner/README.md
@@ -1,0 +1,67 @@
+# InstallPlanner
+
+InstallPlanner is a monorepo containing a FastAPI backend and a Next.js frontend for planning installer schedules. The project ships with Docker Compose for local development and a sample Caddy reverse proxy configuration.
+
+## Getting started
+
+### Prerequisites
+- Docker and Docker Compose
+
+### Environment variables
+Copy `.env.example` to `.env` (or export the variables manually):
+
+```
+WEB_ORIGIN=http://localhost:3000
+NEXT_PUBLIC_API_BASE=http://localhost:8000
+```
+
+### Run locally with Docker Compose
+
+```bash
+cd ops
+docker compose up --build
+```
+
+- API available at http://localhost:8000
+- Web app available at http://localhost:3000
+
+### Direct backend development
+
+```bash
+cd api
+python -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+uvicorn main:app --reload
+```
+
+### Direct frontend development
+
+```bash
+cd web
+npm install
+npm run dev
+```
+
+## API summary
+- `GET /installers` – list installers
+- `GET /jobs` – list jobs with optional `q` query
+- `POST /overrides` – persist overrides
+- `POST /schedule` – generate a weekly schedule
+- `POST /import/xlsx` – import data from Excel
+- `GET /export/xlsx` – export data to Excel
+- `GET /export/ics` – export schedule as ICS
+- `POST /teams/publish` – push summary to Teams webhook
+
+## Frontend features
+- Dashboard with KPIs and navigation
+- Jobs grid powered by AG Grid with quick filtering and override drawer
+- Weekly schedule view with FullCalendar and Teams publishing shortcut
+
+## Caddy reverse proxy
+A sample `Caddyfile` is available in `ops/caddy/Caddyfile`. Configure TLS certificates for production use.
+
+## Roadmap
+- Replace in-memory storage with a persistent database
+- Enhance scheduling algorithm and conflict resolution
+- Add authentication and role-based access control

--- a/installerplanner/api/Dockerfile
+++ b/installerplanner/api/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/installerplanner/api/core/excel_io.py
+++ b/installerplanner/api/core/excel_io.py
@@ -1,0 +1,97 @@
+"""Excel import/export helpers."""
+from __future__ import annotations
+
+from io import BytesIO
+from typing import Iterable, List, Tuple
+
+import pandas as pd
+
+from .models import Installer, Job, Override
+
+
+INSTALLERS_SHEET = "Installers"
+JOBS_SHEET = "Jobs"
+OVERRIDES_SHEET = "Overrides"
+
+
+def _installers_to_frame(installers: Iterable[Installer]) -> pd.DataFrame:
+    data = [i.dict() for i in installers]
+    return pd.DataFrame(data or [], columns=["id", "name", "tier", "match_score"])
+
+
+def _jobs_to_frame(jobs: Iterable[Job]) -> pd.DataFrame:
+    data = [
+        {
+            "job_id": job.job_id,
+            "name": job.name,
+            "revenue": job.revenue,
+            "duration_days": job.duration_days,
+            "city": job.city,
+            "revenue_bucket": job.revenue_bucket,
+        }
+        for job in jobs
+    ]
+    return pd.DataFrame(
+        data or [],
+        columns=["job_id", "name", "revenue", "duration_days", "city", "revenue_bucket"],
+    )
+
+
+def _overrides_to_frame(overrides: Iterable[Override]) -> pd.DataFrame:
+    data = [o.dict() for o in overrides]
+    return pd.DataFrame(data or [], columns=["job_id", "installer_id", "start_date"])
+
+
+def export_workbook(
+    installers: Iterable[Installer],
+    jobs: Iterable[Job],
+    overrides: Iterable[Override],
+) -> bytes:
+    """Return bytes for an XLSX workbook with the planner data."""
+
+    buffer = BytesIO()
+    with pd.ExcelWriter(buffer, engine="xlsxwriter") as writer:
+        _installers_to_frame(installers).to_excel(writer, sheet_name=INSTALLERS_SHEET, index=False)
+        _jobs_to_frame(jobs).to_excel(writer, sheet_name=JOBS_SHEET, index=False)
+        _overrides_to_frame(overrides).to_excel(writer, sheet_name=OVERRIDES_SHEET, index=False)
+    buffer.seek(0)
+    return buffer.read()
+
+
+def import_workbook(data: bytes) -> Tuple[List[Installer], List[Job], List[Override]]:
+    """Parse an XLSX workbook and return domain models."""
+
+    buffer = BytesIO(data)
+    frames = pd.read_excel(
+        buffer,
+        sheet_name=[INSTALLERS_SHEET, JOBS_SHEET, OVERRIDES_SHEET],
+        dtype={"match_score": float, "revenue": float, "duration_days": int},
+    )
+
+    installers = [Installer(**row) for row in frames[INSTALLERS_SHEET].fillna("").to_dict("records")]
+
+    job_records = frames[JOBS_SHEET].fillna({"city": "", "name": ""}).to_dict("records")
+    jobs = [
+        Job(
+            job_id=str(row["job_id"]),
+            name=str(row["name"]),
+            revenue=float(row["revenue"]),
+            duration_days=int(row["duration_days"]),
+            city=str(row.get("city", "")),
+        )
+        for row in job_records
+    ]
+
+    override_records = frames[OVERRIDES_SHEET].dropna(subset=["job_id", "installer_id"]).to_dict("records")
+    overrides = [
+        Override(
+            job_id=str(row["job_id"]),
+            installer_id=str(row["installer_id"]),
+            start_date=pd.to_datetime(row["start_date"]).date(),
+        )
+        for row in override_records
+    ]
+
+    return installers, jobs, overrides
+
+

--- a/installerplanner/api/core/ics_export.py
+++ b/installerplanner/api/core/ics_export.py
@@ -1,0 +1,47 @@
+"""ICS export helpers."""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from typing import Iterable
+
+from dateutil import tz
+
+from .models import ScheduleItem
+
+
+def build_ics(schedule: Iterable[ScheduleItem], calendar_name: str = "InstallPlanner") -> bytes:
+    """Generate an ICS payload from the provided schedule items."""
+
+    tzinfo = tz.UTC
+    now = datetime.now(tzinfo)
+
+    lines = [
+        "BEGIN:VCALENDAR",
+        "VERSION:2.0",
+        "PRODID:-//InstallPlanner//EN",
+        f"NAME:{calendar_name}",
+        f"X-WR-CALNAME:{calendar_name}",
+        "CALSCALE:GREGORIAN",
+    ]
+
+    for item in schedule:
+        uid = f"{item.job_id}-{item.installer_id}@installplanner"
+
+        lines.extend(
+            [
+                "BEGIN:VEVENT",
+                f"UID:{uid}",
+                f"DTSTAMP:{now.strftime('%Y%m%dT%H%M%SZ')}",
+                f"DTSTART;VALUE=DATE:{item.start_date.strftime('%Y%m%d')}",
+                f"DTEND;VALUE=DATE:{(item.end_date + timedelta(days=1)).strftime('%Y%m%d')}",
+                f"SUMMARY:{item.job_name} - {item.installer_name}",
+                f"DESCRIPTION:Revenue bucket: {item.revenue_bucket}\\nDuration: {item.duration_days} day(s)",
+                "END:VEVENT",
+            ]
+        )
+
+    lines.append("END:VCALENDAR")
+    ics_content = "\r\n".join(lines) + "\r\n"
+    return ics_content.encode("utf-8")
+
+

--- a/installerplanner/api/core/models.py
+++ b/installerplanner/api/core/models.py
@@ -1,0 +1,79 @@
+"""Data models for InstallPlanner backend."""
+from __future__ import annotations
+
+from datetime import date
+from typing import List
+
+from pydantic import BaseModel, Field, validator
+
+
+class Installer(BaseModel):
+    """Represents an installer that can be scheduled."""
+
+    id: str = Field(..., description="Unique identifier for the installer")
+    name: str = Field(..., description="Display name")
+    tier: str = Field(..., description="Business tier classification")
+    match_score: float = Field(0.0, description="Placeholder score for matching quality")
+
+
+class Job(BaseModel):
+    """Represents a job that must be scheduled."""
+
+    job_id: str = Field(..., description="Unique job identifier")
+    name: str = Field(..., description="Job description")
+    revenue: float = Field(..., ge=0, description="Total revenue for the job")
+    duration_days: int = Field(..., ge=1, description="Number of days required")
+    city: str = Field(..., description="City where the job takes place")
+
+    @property
+    def revenue_bucket(self) -> str:
+        """Bucket the revenue into predefined ranges."""
+
+        amount = self.revenue
+        if amount < 10_000:
+            return "0-10k"
+        if amount < 50_000:
+            return "10-50k"
+        if amount < 100_000:
+            return "50-100k"
+        if amount < 200_000:
+            return "100-200k"
+        return "200-300k"
+
+
+class Override(BaseModel):
+    """Manual override for placing a job."""
+
+    job_id: str
+    installer_id: str
+    start_date: date
+
+
+class ScheduleItem(BaseModel):
+    """Represents a single scheduled job placement."""
+
+    job_id: str
+    job_name: str
+    installer_id: str
+    installer_name: str
+    start_date: date
+    end_date: date
+    duration_days: int
+    revenue: float
+    revenue_bucket: str
+
+    @validator("end_date")
+    def validate_dates(cls, end_date: date, values: dict[str, object]) -> date:
+        start_date = values.get("start_date")
+        if isinstance(start_date, date) and end_date < start_date:
+            raise ValueError("end_date must be on or after start_date")
+        return end_date
+
+
+class ScheduleResponse(BaseModel):
+    """Wrapper for returning both data and metadata for schedules."""
+
+    items: List[ScheduleItem]
+    generated_at: date
+
+

--- a/installerplanner/api/core/scheduler.py
+++ b/installerplanner/api/core/scheduler.py
@@ -1,0 +1,102 @@
+"""Simple greedy scheduling stub."""
+from __future__ import annotations
+
+from collections import defaultdict
+from datetime import date, timedelta
+from typing import Iterable, List
+
+from .models import Installer, Job, Override, ScheduleItem
+
+
+def _week_start(reference: date | None = None) -> date:
+    reference = reference or date.today()
+    return reference - timedelta(days=reference.weekday())
+
+
+def _apply_override(
+    job: Job,
+    override: Override,
+    installers: dict[str, Installer],
+) -> ScheduleItem | None:
+    installer = installers.get(override.installer_id)
+    if not installer:
+        return None
+    end_date = override.start_date + timedelta(days=job.duration_days - 1)
+    return ScheduleItem(
+        job_id=job.job_id,
+        job_name=job.name,
+        installer_id=installer.id,
+        installer_name=installer.name,
+        start_date=override.start_date,
+        end_date=end_date,
+        duration_days=job.duration_days,
+        revenue=job.revenue,
+        revenue_bucket=job.revenue_bucket,
+    )
+
+
+def build_schedule(
+    installers: Iterable[Installer],
+    jobs: Iterable[Job],
+    overrides: Iterable[Override],
+    reference_date: date | None = None,
+) -> List[ScheduleItem]:
+    """Return a naive, non-overlapping schedule for the given week."""
+
+    installer_map = {inst.id: inst for inst in installers}
+    week_start = _week_start(reference_date)
+    week_end = week_start + timedelta(days=6)
+
+    overrides_by_job = {ov.job_id: ov for ov in overrides}
+    bookings: dict[str, set[date]] = defaultdict(set)
+    scheduled: List[ScheduleItem] = []
+
+    # Handle overrides first
+    for job in jobs:
+        if job.job_id in overrides_by_job:
+            item = _apply_override(job, overrides_by_job[job.job_id], installer_map)
+            if item:
+                for offset in range(job.duration_days):
+                    bookings[item.installer_id].add(item.start_date + timedelta(days=offset))
+                scheduled.append(item)
+
+    remaining_jobs = [job for job in jobs if job.job_id not in overrides_by_job]
+    remaining_jobs.sort(key=lambda j: (-j.revenue, j.job_id))
+
+    for job in remaining_jobs:
+        placed = False
+        for installer in installer_map.values():
+            for offset in range(0, 7):
+                candidate_start = week_start + timedelta(days=offset)
+                candidate_end = candidate_start + timedelta(days=job.duration_days - 1)
+                if candidate_end > week_end:
+                    continue
+
+                span = {candidate_start + timedelta(days=i) for i in range(job.duration_days)}
+                if span & bookings[installer.id]:
+                    continue
+
+                bookings[installer.id].update(span)
+                scheduled.append(
+                    ScheduleItem(
+                        job_id=job.job_id,
+                        job_name=job.name,
+                        installer_id=installer.id,
+                        installer_name=installer.name,
+                        start_date=candidate_start,
+                        end_date=candidate_end,
+                        duration_days=job.duration_days,
+                        revenue=job.revenue,
+                        revenue_bucket=job.revenue_bucket,
+                    )
+                )
+                placed = True
+                break
+            if placed:
+                break
+        # TODO: Implement spill-over weeks or backlog handling for unplaced jobs.
+
+    scheduled.sort(key=lambda item: (item.start_date, item.installer_name, item.job_name))
+    return scheduled
+
+

--- a/installerplanner/api/main.py
+++ b/installerplanner/api/main.py
@@ -1,0 +1,212 @@
+"""FastAPI application for InstallPlanner."""
+from __future__ import annotations
+
+import os
+from datetime import date
+from typing import List, Optional
+
+import requests
+from fastapi import BackgroundTasks, Depends, FastAPI, File, UploadFile
+from fastapi.middleware.cors import CORSMiddleware
+from fastapi.responses import JSONResponse, Response
+from pydantic import BaseModel
+
+from core import excel_io, ics_export, scheduler
+from core.models import Installer, Job, Override, ScheduleItem
+
+
+class ScheduleRequest(BaseModel):
+    """Request payload for building a schedule."""
+
+    reference_date: Optional[date] = None
+    include_overrides: bool = True
+
+
+class TeamsPublishRequest(BaseModel):
+    """Payload for publishing to Microsoft Teams."""
+
+    webhook_url: str
+    title: str
+    lines: List[str]
+    ics_url: str
+
+
+class DataStore:
+    """A very small in-memory persistence layer."""
+
+    def __init__(self) -> None:
+        self.installers: List[Installer] = []
+        self.jobs: List[Job] = []
+        self.overrides: List[Override] = []
+
+    def seed(self) -> None:
+        """Populate the store with sample data when requested."""
+
+        if self.installers or self.jobs:
+            return
+
+        self.installers = [
+            Installer(id="inst-100", name="Acme Installers", tier="Gold", match_score=92.0),
+            Installer(id="inst-101", name="BrightBuild", tier="Silver", match_score=85.0),
+            Installer(id="inst-102", name="Crafted Homes", tier="Bronze", match_score=78.0),
+        ]
+        self.jobs = [
+            Job(job_id="JOB-001", name="Rooftop Solar", revenue=150_000, duration_days=3, city="Denver"),
+            Job(job_id="JOB-002", name="Battery Storage", revenue=80_000, duration_days=2, city="Boulder"),
+            Job(job_id="JOB-003", name="EV Charger", revenue=12_000, duration_days=1, city="Aurora"),
+            Job(job_id="JOB-004", name="Panel Upgrade", revenue=45_000, duration_days=2, city="Fort Collins"),
+            Job(job_id="JOB-005", name="Commercial Solar", revenue=250_000, duration_days=4, city="Colorado Springs"),
+        ]
+        self.overrides = [
+            Override(job_id="JOB-003", installer_id="inst-102", start_date=date.today()),
+        ]
+
+
+store = DataStore()
+if os.getenv("SEED", "0") == "1":
+    store.seed()
+
+app = FastAPI(title="InstallPlanner API", version="0.1.0")
+
+web_origin = os.getenv("WEB_ORIGIN", "http://localhost:3000")
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=[web_origin],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+
+def get_store() -> DataStore:
+    """Dependency that returns the global datastore."""
+
+    return store
+
+
+@app.get("/installers", response_model=List[Installer])
+async def list_installers(store: DataStore = Depends(get_store)) -> List[Installer]:
+    """Return all installers with placeholder match scores."""
+
+    return store.installers
+
+
+@app.get("/jobs", response_model=List[Job])
+async def list_jobs(q: Optional[str] = None, store: DataStore = Depends(get_store)) -> List[Job]:
+    """Return jobs, optionally filtered by a query string."""
+
+    if not q:
+        return store.jobs
+
+    term = q.lower()
+    return [
+        job
+        for job in store.jobs
+        if term in job.job_id.lower()
+        or term in job.name.lower()
+        or term in job.city.lower()
+    ]
+
+
+@app.post("/overrides", response_model=List[Override])
+async def save_overrides(payload: List[Override], store: DataStore = Depends(get_store)) -> List[Override]:
+    """Persist override selections for manual scheduling."""
+
+    store.overrides = payload
+    return store.overrides
+
+
+@app.post("/schedule", response_model=List[ScheduleItem])
+async def build_schedule_endpoint(
+    payload: ScheduleRequest | None = None,
+    store: DataStore = Depends(get_store),
+) -> List[ScheduleItem]:
+    """Return a computed schedule for the requested week."""
+
+    payload = payload or ScheduleRequest()
+    overrides = store.overrides if payload.include_overrides else []
+    return scheduler.build_schedule(store.installers, store.jobs, overrides, payload.reference_date)
+
+
+@app.post("/import/xlsx")
+async def import_xlsx(file: UploadFile = File(...), store: DataStore = Depends(get_store)) -> JSONResponse:
+    """Import planner data from an uploaded workbook."""
+
+    data = await file.read()
+    installers, jobs, overrides = excel_io.import_workbook(data)
+    store.installers = installers
+    store.jobs = jobs
+    store.overrides = overrides
+    return JSONResponse({"status": "ok", "installers": len(installers), "jobs": len(jobs)})
+
+
+@app.get("/export/xlsx")
+async def export_xlsx(store: DataStore = Depends(get_store)) -> Response:
+    """Export the planner data to an Excel workbook."""
+
+    workbook = excel_io.export_workbook(store.installers, store.jobs, store.overrides)
+    return Response(
+        content=workbook,
+        media_type="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        headers={"Content-Disposition": "attachment; filename=installplanner.xlsx"},
+    )
+
+
+@app.get("/export/ics")
+async def export_ics(store: DataStore = Depends(get_store)) -> Response:
+    """Export the current schedule as an ICS file."""
+
+    schedule_items = scheduler.build_schedule(store.installers, store.jobs, store.overrides)
+    ics_bytes = ics_export.build_ics(schedule_items)
+    return Response(
+        content=ics_bytes,
+        media_type="text/calendar",
+        headers={"Content-Disposition": "attachment; filename=installplanner.ics"},
+    )
+
+
+@app.post("/teams/publish")
+async def publish_to_teams(
+    payload: TeamsPublishRequest,
+    background_tasks: BackgroundTasks,
+) -> JSONResponse:
+    """Send an Adaptive Card to a Microsoft Teams webhook."""
+
+    def _post_card() -> None:
+        card = {
+            "type": "message",
+            "attachments": [
+                {
+                    "contentType": "application/vnd.microsoft.card.adaptive",
+                    "content": {
+                        "type": "AdaptiveCard",
+                        "$schema": "http://adaptivecards.io/schemas/adaptive-card.json",
+                        "version": "1.4",
+                        "body": [
+                            {"type": "TextBlock", "weight": "Bolder", "size": "Large", "text": payload.title},
+                            {
+                                "type": "TextBlock",
+                                "wrap": True,
+                                "text": "\n".join(payload.lines),
+                            },
+                        ],
+                        "actions": [
+                            {
+                                "type": "Action.OpenUrl",
+                                "title": "Download ICS",
+                                "url": payload.ics_url,
+                            }
+                        ],
+                    },
+                }
+            ],
+        }
+        try:
+            requests.post(payload.webhook_url, json=card, timeout=5)
+        except requests.RequestException:
+            pass  # For now we swallow errors; future versions should log.
+
+    background_tasks.add_task(_post_card)
+    return JSONResponse({"status": "queued"})
+
+

--- a/installerplanner/api/requirements.txt
+++ b/installerplanner/api/requirements.txt
@@ -1,0 +1,9 @@
+fastapi
+uvicorn[standard]
+pydantic
+pandas
+openpyxl
+xlsxwriter
+python-dateutil
+requests
+

--- a/installerplanner/ops/caddy/Caddyfile
+++ b/installerplanner/ops/caddy/Caddyfile
@@ -1,0 +1,9 @@
+:80 {
+  handle_path /api/* {
+    reverse_proxy api:8000
+  }
+
+  handle {
+    reverse_proxy web:3000
+  }
+}

--- a/installerplanner/ops/docker-compose.yml
+++ b/installerplanner/ops/docker-compose.yml
@@ -1,0 +1,19 @@
+version: "3.9"
+services:
+  api:
+    build: ../api
+    environment:
+      WEB_ORIGIN: http://localhost:3000
+      SEED: "1"
+    ports:
+      - "8000:8000"
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+  web:
+    build: ../web
+    environment:
+      NEXT_PUBLIC_API_BASE: http://localhost:8000
+    ports:
+      - "3000:3000"
+    command: npm run dev
+    depends_on:
+      - api

--- a/installerplanner/web/Dockerfile
+++ b/installerplanner/web/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+RUN npm run build
+
+EXPOSE 3000
+
+CMD ["npm", "run", "start"]

--- a/installerplanner/web/app/globals.css
+++ b/installerplanner/web/app/globals.css
@@ -1,0 +1,13 @@
+:root {
+  color-scheme: light;
+}
+
+body {
+  margin: 0;
+  font-family: "Roboto", sans-serif;
+  background-color: #f5f5f5;
+}
+
+main {
+  min-height: 100vh;
+}

--- a/installerplanner/web/app/installers/page.tsx
+++ b/installerplanner/web/app/installers/page.tsx
@@ -1,0 +1,19 @@
+import { Container, Typography } from "@mui/material";
+
+import { fetchInstallers } from "@/lib/api";
+import { InstallersTable } from "@/components/InstallersTable";
+
+export default async function InstallersPage() {
+  const installers = await fetchInstallers();
+
+  return (
+    <main>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Installers
+        </Typography>
+        <InstallersTable installers={installers} />
+      </Container>
+    </main>
+  );
+}

--- a/installerplanner/web/app/jobs/page.tsx
+++ b/installerplanner/web/app/jobs/page.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { Box, CircularProgress, Container, Typography } from "@mui/material";
+
+import { JobsGrid } from "@/components/JobsGrid";
+import { OverridesDrawer } from "@/components/OverridesDrawer";
+import type { Installer, Job, Override } from "@/lib/api";
+import { fetchInstallers, fetchJobs } from "@/lib/api";
+
+export default function JobsPage() {
+  const [jobs, setJobs] = useState<Job[]>([]);
+  const [installers, setInstallers] = useState<Installer[]>([]);
+  const [overrides, setOverrides] = useState<Override[]>([]);
+  const [selectedJob, setSelectedJob] = useState<Job | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      try {
+        const [jobsData, installersData] = await Promise.all([fetchJobs(), fetchInstallers()]);
+        setJobs(jobsData);
+        setInstallers(installersData);
+      } finally {
+        setLoading(false);
+      }
+    };
+    load();
+  }, []);
+
+  if (loading) {
+    return (
+      <Box sx={{ display: "flex", justifyContent: "center", alignItems: "center", minHeight: "50vh" }}>
+        <CircularProgress />
+      </Box>
+    );
+  }
+
+  return (
+    <main>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Typography variant="h4" gutterBottom>
+          Jobs
+        </Typography>
+        <JobsGrid jobs={jobs} onOpen={setSelectedJob} />
+        <OverridesDrawer
+          job={selectedJob}
+          installers={installers}
+          overrides={overrides}
+          onClose={(updated) => {
+            if (updated) {
+              setOverrides(updated);
+            }
+            setSelectedJob(null);
+          }}
+        />
+      </Container>
+    </main>
+  );
+}

--- a/installerplanner/web/app/layout.tsx
+++ b/installerplanner/web/app/layout.tsx
@@ -1,0 +1,37 @@
+import "@/app/globals.css";
+import "@fullcalendar/daygrid/main.css";
+import "ag-grid-community/styles/ag-grid.css";
+import "ag-grid-community/styles/ag-theme-alpine.css";
+import { CssBaseline, ThemeProvider, createTheme } from "@mui/material";
+import type { Metadata } from "next";
+import { ReactNode } from "react";
+
+const theme = createTheme({
+  palette: {
+    mode: "light",
+    primary: {
+      main: "#0d47a1"
+    },
+    secondary: {
+      main: "#ff8f00"
+    }
+  }
+});
+
+export const metadata: Metadata = {
+  title: "InstallPlanner",
+  description: "Plan installer schedules with ease"
+};
+
+export default function RootLayout({ children }: { children: ReactNode }) {
+  return (
+    <html lang="en">
+      <body>
+        <ThemeProvider theme={theme}>
+          <CssBaseline />
+          {children}
+        </ThemeProvider>
+      </body>
+    </html>
+  );
+}

--- a/installerplanner/web/app/page.tsx
+++ b/installerplanner/web/app/page.tsx
@@ -1,0 +1,48 @@
+import { Box, Button, Card, CardContent, Container, Grid, Typography } from "@mui/material";
+import Link from "next/link";
+
+import { fetchInstallers, fetchJobs } from "@/lib/api";
+
+export default async function HomePage() {
+  const [installers, jobs] = await Promise.all([fetchInstallers(), fetchJobs()]);
+
+  return (
+    <main>
+      <Container maxWidth="lg" sx={{ py: 6 }}>
+        <Typography variant="h3" gutterBottom>
+          InstallPlanner Dashboard
+        </Typography>
+        <Grid container spacing={3}>
+          <Grid item xs={12} md={6}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6">Installers</Typography>
+                <Typography variant="h3" color="primary">
+                  {installers.length}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+          <Grid item xs={12} md={6}>
+            <Card>
+              <CardContent>
+                <Typography variant="h6">Jobs</Typography>
+                <Typography variant="h3" color="primary">
+                  {jobs.length}
+                </Typography>
+              </CardContent>
+            </Card>
+          </Grid>
+        </Grid>
+        <Box sx={{ display: "flex", gap: 2, mt: 4 }}>
+          <Button component={Link} href="/jobs" variant="contained" color="primary">
+            View Jobs
+          </Button>
+          <Button component={Link} href="/schedule" variant="outlined" color="primary">
+            View Schedule
+          </Button>
+        </Box>
+      </Container>
+    </main>
+  );
+}

--- a/installerplanner/web/app/schedule/page.tsx
+++ b/installerplanner/web/app/schedule/page.tsx
@@ -1,0 +1,68 @@
+"use client";
+
+import { useState } from "react";
+import { Box, Button, Container, Stack, Typography } from "@mui/material";
+
+import { WeekCalendar } from "@/components/WeekCalendar";
+import type { ScheduleItem } from "@/lib/api";
+import { buildSchedule, publishToTeams } from "@/lib/api";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+
+export default function SchedulePage() {
+  const [items, setItems] = useState<ScheduleItem[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const handleBuild = async () => {
+    setLoading(true);
+    try {
+      const schedule = await buildSchedule();
+      setItems(schedule);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handlePublish = async () => {
+    if (!items.length) {
+      alert("Build a schedule before publishing.");
+      return;
+    }
+    const webhook = window.prompt("Enter the Microsoft Teams webhook URL");
+    if (!webhook) return;
+    await publishToTeams({
+      webhook_url: webhook,
+      title: "Weekly Installation Schedule",
+      lines: items.map((item) => `${item.job_name} – ${item.installer_name} (${item.start_date})`),
+      ics_url: `${API_BASE}/export/ics`
+    });
+    alert("Schedule published to Teams");
+  };
+
+  return (
+    <main>
+      <Container maxWidth="lg" sx={{ py: 4 }}>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={2} alignItems="center" justifyContent="space-between">
+          <Typography variant="h4">Schedule</Typography>
+          <Box sx={{ display: "flex", gap: 2 }}>
+            <Button variant="contained" onClick={handleBuild} disabled={loading}>
+              {loading ? "Building..." : "Build Schedule"}
+            </Button>
+            <Button variant="outlined" onClick={handlePublish}>
+              Publish to Teams
+            </Button>
+          </Box>
+        </Stack>
+        <Box sx={{ mt: 4, backgroundColor: "white", p: 2, borderRadius: 1 }}>
+          {items.length ? (
+            <WeekCalendar items={items} />
+          ) : (
+            <Typography variant="body1" color="text.secondary">
+              Click “Build Schedule” to generate events for this week.
+            </Typography>
+          )}
+        </Box>
+      </Container>
+    </main>
+  );
+}

--- a/installerplanner/web/components/InstallersTable.tsx
+++ b/installerplanner/web/components/InstallersTable.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import { Box } from "@mui/material";
+import { DataGrid, GridColDef } from "@mui/x-data-grid";
+
+import type { Installer } from "@/lib/api";
+
+interface Props {
+  installers: Installer[];
+}
+
+const columns: GridColDef[] = [
+  { field: "name", headerName: "Name", flex: 1 },
+  { field: "tier", headerName: "Tier", flex: 1 },
+  {
+    field: "match_score",
+    headerName: "Match Score",
+    flex: 1,
+    valueFormatter: ({ value }) => `${value}%`
+  }
+];
+
+export function InstallersTable({ installers }: Props) {
+  return (
+    <Box sx={{ height: 500, width: "100%", backgroundColor: "white" }}>
+      <DataGrid rows={installers} columns={columns} getRowId={(row) => row.id} disableRowSelectionOnClick />
+    </Box>
+  );
+}

--- a/installerplanner/web/components/JobsGrid.tsx
+++ b/installerplanner/web/components/JobsGrid.tsx
@@ -1,0 +1,66 @@
+"use client";
+
+import { useCallback, useMemo, useState } from "react";
+import { Box, TextField } from "@mui/material";
+import { AgGridReact } from "ag-grid-react";
+import type { ColDef } from "ag-grid-community";
+
+import type { Job } from "@/lib/api";
+import { revenueFormatter } from "@/lib/api";
+
+interface Props {
+  jobs: Job[];
+  onOpen: (job: Job) => void;
+}
+
+export function JobsGrid({ jobs, onOpen }: Props) {
+  const [quickFilter, setQuickFilter] = useState("");
+
+  const columns: ColDef<Job>[] = useMemo(
+    () => [
+      { field: "job_id", headerName: "Job ID", flex: 1 },
+      { field: "name", headerName: "Name", flex: 1.5 },
+      {
+        field: "revenue",
+        headerName: "Revenue",
+        flex: 1,
+        valueFormatter: ({ value }) => revenueFormatter(value as number)
+      },
+      { field: "revenue_bucket", headerName: "Revenue Bucket", flex: 1 },
+      { field: "duration_days", headerName: "Duration (days)", flex: 1 },
+      { field: "city", headerName: "City", flex: 1 }
+    ],
+    []
+  );
+
+  const onRowDoubleClicked = useCallback(
+    (event: any) => {
+      if (event?.data) {
+        onOpen(event.data as Job);
+      }
+    },
+    [onOpen]
+  );
+
+  return (
+    <Box>
+      <TextField
+        label="Quick filter"
+        value={quickFilter}
+        onChange={(event) => setQuickFilter(event.target.value)}
+        sx={{ mb: 2 }}
+        fullWidth
+      />
+      <div className="ag-theme-alpine" style={{ height: 600, width: "100%" }}>
+        <AgGridReact
+          rowData={jobs}
+          columnDefs={columns}
+          domLayout="normal"
+          animateRows
+          onRowDoubleClicked={onRowDoubleClicked}
+          quickFilterText={quickFilter}
+        />
+      </div>
+    </Box>
+  );
+}

--- a/installerplanner/web/components/OverridesDrawer.tsx
+++ b/installerplanner/web/components/OverridesDrawer.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Drawer,
+  FormControl,
+  InputLabel,
+  MenuItem,
+  Select,
+  TextField,
+  Typography
+} from "@mui/material";
+
+import type { Installer, Job, Override } from "@/lib/api";
+import { saveOverrides } from "@/lib/api";
+
+interface Props {
+  job: Job | null;
+  installers: Installer[];
+  overrides: Override[];
+  onClose: (overrides: Override[] | null) => void;
+}
+
+export function OverridesDrawer({ job, installers, overrides, onClose }: Props) {
+  const [installerId, setInstallerId] = useState<string>(job ? installers[0]?.id ?? "" : "");
+  const [startDate, setStartDate] = useState<string>(new Date().toISOString().slice(0, 10));
+  const [error, setError] = useState<string | null>(null);
+
+  const defaultInstallerId = useMemo(() => installers[0]?.id ?? "", [installers]);
+
+  useEffect(() => {
+    if (job) {
+      const existing = overrides.find((o) => o.job_id === job.job_id);
+      setInstallerId(existing?.installer_id ?? defaultInstallerId);
+      setStartDate(existing?.start_date ?? new Date().toISOString().slice(0, 10));
+      setError(null);
+    }
+  }, [job, overrides, defaultInstallerId]);
+
+  if (!job) {
+    return null;
+  }
+
+  const handleSave = async () => {
+    if (!installerId || !startDate) {
+      setError("Installer and start date are required");
+      return;
+    }
+
+    const updated: Override[] = overrides.filter((o) => o.job_id !== job.job_id).concat({
+      job_id: job.job_id,
+      installer_id: installerId,
+      start_date: startDate
+    });
+
+    try {
+      const saved = await saveOverrides(updated);
+      onClose(saved);
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <Drawer anchor="right" open={Boolean(job)} onClose={() => onClose(null)}>
+      <Box sx={{ width: 360, p: 3, display: "flex", flexDirection: "column", gap: 2 }}>
+        <Typography variant="h6">Create Override</Typography>
+        <Typography variant="body2" color="text.secondary">
+          {job.name} ({job.job_id})
+        </Typography>
+        {error && <Alert severity="error">{error}</Alert>}
+        <FormControl fullWidth>
+          <InputLabel id="installer-select-label">Installer</InputLabel>
+          <Select
+            labelId="installer-select-label"
+            value={installerId}
+            label="Installer"
+            onChange={(event) => setInstallerId(event.target.value)}
+          >
+            {installers.map((installer) => (
+              <MenuItem key={installer.id} value={installer.id}>
+                {installer.name} ({installer.tier})
+              </MenuItem>
+            ))}
+          </Select>
+        </FormControl>
+        <TextField
+          label="Start date"
+          type="date"
+          value={startDate}
+          onChange={(event) => setStartDate(event.target.value)}
+          InputLabelProps={{ shrink: true }}
+        />
+        <Box sx={{ display: "flex", gap: 1, mt: 2 }}>
+          <Button variant="contained" onClick={handleSave}>
+            Save
+          </Button>
+          <Button variant="text" onClick={() => onClose(null)}>
+            Cancel
+          </Button>
+        </Box>
+      </Box>
+    </Drawer>
+  );
+}

--- a/installerplanner/web/components/WeekCalendar.tsx
+++ b/installerplanner/web/components/WeekCalendar.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import { useMemo } from "react";
+import FullCalendar from "@fullcalendar/react";
+import dayGridPlugin from "@fullcalendar/daygrid";
+import interactionPlugin from "@fullcalendar/interaction";
+import type { EventContentArg, EventInput } from "@fullcalendar/core";
+
+import type { ScheduleItem } from "@/lib/api";
+
+
+interface Props {
+  items: ScheduleItem[];
+}
+
+export function WeekCalendar({ items }: Props) {
+  const events: EventInput[] = useMemo(
+    () =>
+      items.map((item) => ({
+        id: item.job_id,
+        title: `${item.job_name} (${item.installer_name})`,
+        start: item.start_date,
+        end: (() => {
+          const end = new Date(item.end_date);
+          end.setDate(end.getDate() + 1);
+          return end;
+        })(),
+        allDay: true,
+        extendedProps: item
+      })),
+    [items]
+  );
+
+  const renderEventContent = (arg: EventContentArg) => {
+    return (
+      <div title={`${arg.event.extendedProps.revenue_bucket} • ${arg.event.extendedProps.duration_days} day(s)`}>
+        <strong>{arg.event.title}</strong>
+      </div>
+    );
+  };
+
+  return (
+    <FullCalendar
+      plugins={[dayGridPlugin, interactionPlugin]}
+      initialView="dayGridWeek"
+      events={events}
+      headerToolbar={{ left: "", center: "", right: "" }}
+      eventContent={renderEventContent}
+      height="auto"
+    />
+  );
+}

--- a/installerplanner/web/lib/api.ts
+++ b/installerplanner/web/lib/api.ts
@@ -1,0 +1,116 @@
+import { z } from "zod";
+
+const API_BASE = process.env.NEXT_PUBLIC_API_BASE ?? "http://localhost:8000";
+
+const installerSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  tier: z.string(),
+  match_score: z.number()
+});
+
+const jobSchema = z.object({
+  job_id: z.string(),
+  name: z.string(),
+  revenue: z.number(),
+  duration_days: z.number(),
+  city: z.string()
+});
+
+export type Installer = z.infer<typeof installerSchema>;
+export type Job = z.infer<typeof jobSchema> & { revenue_bucket: string };
+
+const overrideSchema = z.object({
+  job_id: z.string(),
+  installer_id: z.string(),
+  start_date: z.string()
+});
+
+const scheduleItemSchema = z.object({
+  job_id: z.string(),
+  job_name: z.string(),
+  installer_id: z.string(),
+  installer_name: z.string(),
+  start_date: z.string(),
+  end_date: z.string(),
+  duration_days: z.number(),
+  revenue: z.number(),
+  revenue_bucket: z.string()
+});
+
+export type ScheduleItem = z.infer<typeof scheduleItemSchema>;
+export type Override = z.infer<typeof overrideSchema>;
+
+async function handleResponse<T>(res: Response, schema: z.ZodType<T>): Promise<T> {
+  if (!res.ok) {
+    throw new Error(`API request failed with ${res.status}`);
+  }
+  const json = await res.json();
+  return schema.parse(json);
+}
+
+export async function fetchInstallers(): Promise<Installer[]> {
+  const res = await fetch(`${API_BASE}/installers`, { cache: "no-store" });
+  return handleResponse(res, z.array(installerSchema));
+}
+
+export async function fetchJobs(query?: string): Promise<Job[]> {
+  const url = new URL(`${API_BASE}/jobs`);
+  if (query) {
+    url.searchParams.set("q", query);
+  }
+  const res = await fetch(url.toString(), { cache: "no-store" });
+  const jobs = await handleResponse(res, z.array(jobSchema));
+  return jobs.map((job) => ({
+    ...job,
+    revenue_bucket: bucketRevenue(job.revenue)
+  }));
+}
+
+export async function saveOverrides(overrides: Override[]): Promise<Override[]> {
+  const res = await fetch(`${API_BASE}/overrides`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(overrides)
+  });
+  return handleResponse(res, z.array(overrideSchema));
+}
+
+export async function buildSchedule(): Promise<ScheduleItem[]> {
+  const res = await fetch(`${API_BASE}/schedule`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({})
+  });
+  return handleResponse(res, z.array(scheduleItemSchema));
+}
+
+export async function publishToTeams(payload: {
+  webhook_url: string;
+  title: string;
+  lines: string[];
+  ics_url: string;
+}): Promise<void> {
+  const res = await fetch(`${API_BASE}/teams/publish`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(payload)
+  });
+  if (!res.ok) {
+    throw new Error("Failed to publish to Teams");
+  }
+}
+
+export function revenueFormatter(value: number): string {
+  return new Intl.NumberFormat("en-US", { style: "currency", currency: "USD", maximumFractionDigits: 0 }).format(
+    value
+  );
+}
+
+export function bucketRevenue(amount: number): string {
+  if (amount < 10_000) return "0-10k";
+  if (amount < 50_000) return "10-50k";
+  if (amount < 100_000) return "50-100k";
+  if (amount < 200_000) return "100-200k";
+  return "200-300k";
+}

--- a/installerplanner/web/next-env.d.ts
+++ b/installerplanner/web/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited

--- a/installerplanner/web/next.config.js
+++ b/installerplanner/web/next.config.js
@@ -1,0 +1,9 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+  experimental: {
+    appDir: true
+  }
+};
+
+module.exports = nextConfig;

--- a/installerplanner/web/package.json
+++ b/installerplanner/web/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "installplanner-web",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint"
+  },
+  "dependencies": {
+    "@emotion/react": "^11.11.3",
+    "@emotion/styled": "^11.11.0",
+    "@fullcalendar/daygrid": "^6.1.11",
+    "@fullcalendar/interaction": "^6.1.11",
+    "@fullcalendar/react": "^6.1.11",
+    "@mui/material": "^5.15.15",
+    "@mui/x-data-grid": "^6.19.5",
+    "ag-grid-community": "^32.2.0",
+    "ag-grid-react": "^32.2.0",
+    "date-fns": "^3.3.1",
+    "next": "14.2.3",
+    "react": "18.2.0",
+    "react-dom": "18.2.0",
+    "zod": "^3.22.4"
+  },
+  "devDependencies": {
+    "@types/node": "20.11.25",
+    "@types/react": "18.2.66",
+    "@types/react-dom": "18.2.22",
+    "eslint": "8.57.0",
+    "eslint-config-next": "14.2.3",
+    "typescript": "5.4.5"
+  }
+}

--- a/installerplanner/web/tsconfig.json
+++ b/installerplanner/web/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./*"]
+    }
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- set up FastAPI backend with scheduling core, Excel/ICS utilities, and Teams publishing webhook
- scaffold Next.js 14 frontend with dashboards, jobs grid overrides, and weekly calendar UX
- add Docker Compose and Caddy reverse proxy configuration for local and production setups

## Testing
- python -m compileall installerplanner/api

------
https://chatgpt.com/codex/tasks/task_e_68e448c1fbd88323b195f93bfc79673c